### PR TITLE
pysocks added for the sock4 argument

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ colorama
 lxml
 requests
 termcolor
+pysocks


### PR DESCRIPTION
pysocks is not yet included by default with the latest Python (tested on Windows)